### PR TITLE
chore(i): Remove temp modules replace

### DIFF
--- a/host-go/go.mod
+++ b/host-go/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	github.com/bytecodealliance/wasmtime-go/v35 v35.0.0
 	github.com/sourcenetwork/immutable v0.3.0
-	github.com/sourcenetwork/lens/tests/modules v0.0.0-00010101000000-000000000000
+	github.com/sourcenetwork/lens/tests/modules v0.0.0-20250801165343-50437dee953e
 	github.com/stretchr/testify v1.10.0
 	github.com/tetratelabs/wazero v1.9.0
 	github.com/wasmerio/wasmer-go v1.0.4
@@ -17,5 +17,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/sourcenetwork/lens/tests/modules => ../tests/modules

--- a/host-go/go.sum
+++ b/host-go/go.sum
@@ -12,6 +12,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sourcenetwork/immutable v0.3.0 h1:gHPtGvLrTBTK5YpDAhMU+u+S8v1F6iYmc3nbZLryMdc=
 github.com/sourcenetwork/immutable v0.3.0/go.mod h1:GD7ceuh/HD7z6cdIwzKK2ctzgZ1qqYFJpsFp+8qYnbI=
+github.com/sourcenetwork/lens/tests/modules v0.0.0-20250801165343-50437dee953e h1:XpL577LUabRSEG1OLt6GBbIKQG/8HxLF1M+EBKbP3gM=
+github.com/sourcenetwork/lens/tests/modules v0.0.0-20250801165343-50437dee953e/go.mod h1:MMypQqKfWRVzzJb+bZBN80eD7uJM38yC5aGIl8+2SWM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -3,7 +3,7 @@ module github.com/sourcenetwork/lens/tests/integration
 go 1.23
 
 require (
-	github.com/sourcenetwork/lens/tests/modules v0.0.0-00010101000000-000000000000
+	github.com/sourcenetwork/lens/tests/modules v0.0.0-20250801165343-50437dee953e
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -12,5 +12,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/sourcenetwork/lens/tests/modules => ../modules


### PR DESCRIPTION
## Relevant issue(s)

Resolves #114 

## Description

Removes temporary `modules` package replace's now that the `modules` package exists with the correct URLs in `main` branch.