### PR TITLE
fix: Add WithTxnSource option

### DIFF
--- a/host-go/node/node.go
+++ b/host-go/node/node.go
@@ -57,8 +57,8 @@ func New(ctx context.Context, opts ...Option) (*Node, error) {
 		})
 	}
 
-	if !o.TxnProvider.HasValue() {
-		o.TxnProvider = immutable.Some[store.TxnSource](&inMemoryTxnSource{store: o.Rootstore.Value()})
+	if !o.TxnSource.HasValue() {
+		o.TxnSource = immutable.Some[store.TxnSource](&inMemoryTxnSource{store: o.Rootstore.Value()})
 	}
 
 	if !o.PoolSize.HasValue() {
@@ -106,7 +106,7 @@ func New(ctx context.Context, opts ...Option) (*Node, error) {
 		onClose: onClose,
 		Options: o,
 		Store: store.New(
-			o.TxnProvider.Value(),
+			o.TxnSource.Value(),
 			o.PoolSize.Value(),
 			o.Runtime.Value(),
 			o.BlockstoreNamespace.Value(),

--- a/host-go/node/option.go
+++ b/host-go/node/option.go
@@ -16,7 +16,7 @@ import (
 type Options struct {
 	Path                immutable.Option[string]
 	Rootstore           immutable.Option[corekv.TxnReaderWriter]
-	TxnProvider         immutable.Option[store.TxnSource]
+	TxnSource           immutable.Option[store.TxnSource]
 	PoolSize            immutable.Option[int]
 	Runtime             immutable.Option[module.Runtime]
 	BlockstoreNamespace immutable.Option[string]
@@ -83,5 +83,11 @@ func WithP2PDisabled(disableP2P bool) Option {
 func WithP2Poptions(opts ...sourceP2P.NodeOpt) Option {
 	return func(opt *Options) {
 		opt.P2POptions = opts
+	}
+}
+
+func WithTxnSource(txnSource store.TxnSource) Option {
+	return func(opt *Options) {
+		opt.TxnSource = immutable.Some(txnSource)
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #126

## Description

Adds the WithTxnSource option.

Required by Defra.

Previously I had added it to the Option struct, but missed the option func.  The struct property has been renamed for consistency.